### PR TITLE
Switch to use of personal licenses

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -66,7 +66,7 @@ rule pseudobulk_dataset:
     script:
         "scripts/pseudobulk_data_elements.R"
 
-rule ui_diff_targets_cells: #UI
+rule set_gurobi_license: #UI
     params:
         ui=True
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -16,10 +16,11 @@ rule fix_license_formatting:
         txt="output/gurobi_license_string.txt",
     output:
         lic="output/gurobi.lic"
-    shell:
-        """
-        sed 's/"//g' {input.txt} | sed 's/\\n/\n/g' > {output.lic}
-        """
+    run:
+        with open(input.txt, 'r') as input_file:
+            text=input_file.read().strip()
+        with open(output.lic, 'w') as output_file:
+            output_file.write(text.replace('"','').replace('\\n', '\n'))
 
 rule get_dataset_and_summarize:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -66,6 +66,12 @@ rule pseudobulk_dataset:
     script:
         "scripts/pseudobulk_data_elements.R"
 
+rule ui_diff_targets_cells: #UI
+    params:
+        ui=True
+    output:
+        ["output/gurobi.lic"]
+
 rule run_compass:
     params:
         species=config["species"]
@@ -81,7 +87,7 @@ rule run_compass:
         lipid_reactions="output/compass_output/LIPID_META_SUBSYSTEM/reactions.tsv",
         AA_reactions="output/compass_output/AA_META_SUBSYSTEM/reactions.tsv"
     singularity:
-        "/dscolab/vulcan/containers/compass.sif"
+        "/dscolab/vulcan/containers/compass-personal-license.sif"
     shell:
         """
         if [ "{params.species}" = "human" ]; then

--- a/Snakefile
+++ b/Snakefile
@@ -5,6 +5,12 @@ rule all:
         thumbnail="output/red_blue.png",
         compass_tgz="output/compass.tar.gz"
 
+rule set_gurobi_license: #UI
+    params:
+        ui=True
+    output:
+        ["output/gurobi.lic"]
+
 rule get_dataset_and_summarize:
     params:
         dataset_name=config["dataset_name"]
@@ -66,15 +72,10 @@ rule pseudobulk_dataset:
     script:
         "scripts/pseudobulk_data_elements.R"
 
-rule set_gurobi_license: #UI
-    params:
-        ui=True
-    output:
-        ["output/gurobi.lic"]
-
 rule run_compass:
     params:
         species=config["species"]
+        gurobi_lic="output/gurobi.lic"
     input:
         pseudo_matrix="output/delog_pseudobulk_matrix.tsv",
         meta_subsystems="resources/meta_subsystems.txt"

--- a/Snakefile
+++ b/Snakefile
@@ -5,11 +5,21 @@ rule all:
         thumbnail="output/red_blue.png",
         compass_tgz="output/compass.tar.gz"
 
-rule set_gurobi_license: #UI
+rule get_gurobi_license: #UI
     params:
         ui=True
     output:
-        ["output/gurobi.lic"]
+        ["output/gurobi_license_string.txt"]
+
+rule fix_license_formatting:
+    input:
+        txt="output/gurobi_license_string.txt",
+    output:
+        lic="output/gurobi.lic"
+    shell:
+        """
+        sed 's/"//g' {input.txt} | sed 's/\\n/\n/g' > {output.lic}
+        """
 
 rule get_dataset_and_summarize:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -75,8 +75,8 @@ rule pseudobulk_dataset:
 rule run_compass:
     params:
         species=config["species"]
-        gurobi_lic="output/gurobi.lic"
     input:
+        gurobi_lic="output/gurobi.lic",
         pseudo_matrix="output/delog_pseudobulk_matrix.tsv",
         meta_subsystems="resources/meta_subsystems.txt"
     threads: 30

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -11,4 +11,4 @@ default-resources:
 jobs: 5 # How many jobs can we execute in parallel
 printshellcmds: True
 restart-times: 0 # How many times do retry jobs that fail
-singularity-args: ' "-B output/gurobi.lic:/src/compass/compass/gurobi.lic" '
+singularity-args: " -B output/gurobi.lic:/src/compass/compass/gurobi.lic "

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -7,8 +7,8 @@ default-resources:
     runtime: 60 # in min
     mem_mb: 20000 # 20gbs
     nodes: 1
-    singularity-args: ' "-B output/gurobi.lic:/src/compass/compass/gurobi.lic" '
 
 jobs: 5 # How many jobs can we execute in parallel
 printshellcmds: True
 restart-times: 0 # How many times do retry jobs that fail
+singularity-args: ' "-B output/gurobi.lic:/src/compass/compass/gurobi.lic" '

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -7,7 +7,7 @@ default-resources:
     runtime: 60 # in min
     mem_mb: 20000 # 20gbs
     nodes: 1
-    # slurm_extra: "exclude c4-n20"
+    singularity-args: ' "-B output/gurobi.lic:/src/compass/compass/gurobi.lic" '
 
 jobs: 5 # How many jobs can we execute in parallel
 printshellcmds: True

--- a/resources/vignette.md
+++ b/resources/vignette.md
@@ -6,7 +6,7 @@ This workflow enables differential analysis of Lipid, Amino Acid, and Central Ca
 
 The proprietary Gurobi Optimizer is an inherent component that speeds up the Compass algorithm.  Luckily, Academic licenses are free.
 
-Obtain your 'gurobi.lic' by following the instructions at [this page](https://support.gurobi.com/hc/en-us/articles/13232844297489-How-do-I-set-up-a-Web-License-Service-WLS-license). Then provide the contents of this file to a workflow input.
+Obtain your 'gurobi.lic' by following the instructions at [this page](https://support.gurobi.com/hc/en-us/articles/13232844297489-How-do-I-set-up-a-Web-License-Service-WLS-license). Then provide the contents of this file to the associated workflow input.
 
 ## The Workflow in a bit more detail
 

--- a/resources/vignette.md
+++ b/resources/vignette.md
@@ -1,6 +1,14 @@
 # Workflow for: Targeted Compass Anaylsis of Pseudobulked Single-cell Datasets
 
-This workflow enables differential analysis of Lipid, Amino Acid, and Central Carbon Metabolic Reaction Activities across samples after psuedobulking a single-cell RNAseq dataset. 
+This workflow enables differential analysis of Lipid, Amino Acid, and Central Carbon Metabolic Reaction Activities across samples after psuedobulking a single-cell RNAseq dataset.
+
+## Obtaining your License to run this workflow
+
+The proprietary Gurobi Optimizer is an inherent component that speeds up the Compass algorithm.  Luckily, Academic licenses are free.
+
+Obtain your 'gurobi.lic' by following the instructions at [this page](https://support.gurobi.com/hc/en-us/articles/13232844297489-How-do-I-set-up-a-Web-License-Service-WLS-license). Then provide the contents of this file to a workflow input.
+
+## The Workflow in a bit more detail
 
 The workflow starts with asking a few key parameterizations:
 - dataset selection

--- a/scripts/plot_red_blue.py
+++ b/scripts/plot_red_blue.py
@@ -12,8 +12,7 @@ if matplotlibversion < "3.4":
 group_A_cells = list(pd.read_csv(snakemake.input['group_1_inds'], header=None)[0])[1:]
 group_B_cells = list(pd.read_csv(snakemake.input['group_2_inds'], header=None)[0])[1:]
 # Parse reaction file target
-with open(snakemake.config['post_process_meta_subsystem'], 'r') as file:
-    subsystem_full = json.load(file)
+subsystem_full = snakemake.config['post_process_meta_subsystem']
 subsystem = "carbon" if subsystem_full=="CENTRAL_CARBON_META_SUBSYSTEM" \
     else "lipid" if subsystem_full=="LIPID_META_SUBSYSTEM" \
     else "AA" if subsystem_full=="AA_META_SUBSYSTEM" \

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -61,12 +61,12 @@
     params: [ "post_process_meta_subsystem" ]
 
 ## Input UIs
-- display: "Gurobi License"
-  name: set_gurobi_license
+- display: "Provide Gurobi License"
+  name: get_gurobi_license
   ui_component: "multiline-string"
   doc: "... sets the gurobi license for running compass"
   output:
-    files: ["gurobi.lic"]
+    files: ["gurobi_license_string.txt"]
 - display: "Pseudobulking: Sample Metadata Column Name"
   name: ui_select_sample_metadata
   ui_component: "dropdown"

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -61,10 +61,10 @@
     params: [ "post_process_meta_subsystem" ]
 
 ## Input UIs
-- display: "Provide Gurobi License"
+- display: "Provide your Gurobi License"
   name: get_gurobi_license
   ui_component: "multiline-string"
-  doc: "... sets the gurobi license for running compass"
+  doc: "Provide your personal gurobi.lic file's contents here to establish your license for this integral tool within the Compass algorithm. Follow instructions linked within the help-doc behind the '<book> Workflow' button above, or also described in the Compass team's GitHub repo at https://github.com/wagnerlab-berkeley/Compass?tab=readme-ov-file#obtain-a-gurobi-wls-license"
   output:
     files: ["gurobi_license_string.txt"]
 - display: "Pseudobulking: Sample Metadata Column Name"

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -61,6 +61,12 @@
     params: [ "post_process_meta_subsystem" ]
 
 ## Input UIs
+- display: "Gurobi License"
+  name: set_gurobi_license
+  ui_component: "string"
+  doc: "... sets the gurobi license for running compass"
+  output:
+    files: ["gurobi.lic"]
 - display: "Pseudobulking: Sample Metadata Column Name"
   name: ui_select_sample_metadata
   ui_component: "dropdown"

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -63,7 +63,7 @@
 ## Input UIs
 - display: "Gurobi License"
   name: set_gurobi_license
-  ui_component: "string"
+  ui_component: "multiline-string"
   doc: "... sets the gurobi license for running compass"
   output:
     files: ["gurobi.lic"]


### PR DESCRIPTION
This PR adds and input, requisite snakemake steps, a singularity container bind mount, and switch to a different Singularity container which come together to power utilization of a user-provided Gurobi license for running compass.

It also includes a bugfix for the plotting step.