### PR TITLE
Update pseudobulk qc plot and its metadata targets

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -194,9 +194,9 @@ rule plot_carbon_subsystem_comparison:
         reaction_norm_sum="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_sum.tsv",
         reaction_norm_rank="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_rank.tsv"
     output:
-        reaction_stats_csv="output/group_diff_reaction_stats.tsv",
-        subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",
-        plot="output/red_blue.png"
+        reaction_stats_csv="output/carbon_group_diff_reaction_stats.tsv",
+        subsystem_stats_csv="output/carbon_group_diff_subsystem_stats.tsv",
+        plot="output/carbon_red_blue.png"
     singularity:
         "/dscolab/vulcan/containers/archimedes-py.sif"
     script:
@@ -213,9 +213,9 @@ rule plot_lipid_subsystem_comparison:
         reaction_norm_sum="output/compass_output/LIPID_META_SUBSYSTEM/reactions_norm_sum.tsv",
         reaction_norm_rank="output/compass_output/LIPID_META_SUBSYSTEM/reactions_norm_rank.tsv"
     output:
-        reaction_stats_csv="output/group_diff_reaction_stats.tsv",
-        subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",
-        plot="output/red_blue.png"
+        reaction_stats_csv="output/lipid_group_diff_reaction_stats.tsv",
+        subsystem_stats_csv="output/lipid_group_diff_subsystem_stats.tsv",
+        plot="output/lipid_red_blue.png"
     singularity:
         "/dscolab/vulcan/containers/archimedes-py.sif"
     script:
@@ -232,9 +232,9 @@ rule plot_AA_subsystem_comparison:
         reaction_norm_sum="output/compass_output/AA_META_SUBSYSTEMreactions_norm_sum.tsv",
         reaction_norm_rank="output/compass_output/AA_META_SUBSYSTEM/reactions_norm_rank.tsv"
     output:
-        reaction_stats_csv="output/group_diff_reaction_stats.tsv",
-        subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",
-        plot="output/red_blue.png"
+        reaction_stats_csv="output/AA_group_diff_reaction_stats.tsv",
+        subsystem_stats_csv="output/AA_group_diff_subsystem_stats.tsv",
+        plot="output/AA_red_blue.png"
     singularity:
         "/dscolab/vulcan/containers/archimedes-py.sif"
     script:

--- a/Snakefile
+++ b/Snakefile
@@ -114,7 +114,7 @@ rule run_compass:
         lipid_reactions="output/compass_output/LIPID_META_SUBSYSTEM/reactions.tsv",
         AA_reactions="output/compass_output/AA_META_SUBSYSTEM/reactions.tsv"
     singularity:
-        "/dscolab/vulcan/containers/compass-personal-license.sif"
+        "/dscolab/vulcan/containers/vulcan-compass.2026-03-30.sif"
     shell:
         """
         if [ "{params.species}" = "human" ]; then

--- a/Snakefile
+++ b/Snakefile
@@ -183,22 +183,54 @@ rule parse_groupings:
     script:
         "scripts/interpret_diff_groups.py"
 
-rule plot_red_blue:
+rule plot_carbon_subsystem_comparison:
     params:
         post_process_norm_method=config["post_process_norm_method"],
-        post_process_meta_subsystem=config["post_process_meta_subsystem"]
+        post_process_meta_subsystem="CENTRAL_CARBON_META_SUBSYSTEM"
     input:
         group_1_inds="output/diff_group_1__indexes.csv",
         group_2_inds="output/diff_group_2__indexes.csv",
-        carbon_reaction_scores="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reaction_scores.tsv",
-        carbon_reaction_norm_sum="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_sum.tsv",
-        carbon_reaction_norm_rank="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_rank.tsv",
-        lipid_reaction_scores="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reaction_scores.tsv",
-        lipid_reaction_norm_sum="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_sum.tsv",
-        lipid_reaction_norm_rank="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_rank.tsv",
-        AA_reaction_scores="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reaction_scores.tsv",
-        AA_reaction_norm_sum="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_sum.tsv",
-        AA_reaction_norm_rank="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_rank.tsv"
+        reaction_scores="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reaction_scores.tsv",
+        reaction_norm_sum="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_sum.tsv",
+        reaction_norm_rank="output/compass_output/CENTRAL_CARBON_META_SUBSYSTEM/reactions_norm_rank.tsv"
+    output:
+        reaction_stats_csv="output/group_diff_reaction_stats.tsv",
+        subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",
+        plot="output/red_blue.png"
+    singularity:
+        "/dscolab/vulcan/containers/archimedes-py.sif"
+    script:
+        "scripts/plot_red_blue.py"
+
+rule plot_lipid_subsystem_comparison:
+    params:
+        post_process_norm_method=config["post_process_norm_method"],
+        post_process_meta_subsystem="LIPID_META_SUBSYSTEM"
+    input:
+        group_1_inds="output/diff_group_1__indexes.csv",
+        group_2_inds="output/diff_group_2__indexes.csv",
+        reaction_scores="output/compass_output/LIPID_META_SUBSYSTEM/reaction_scores.tsv",
+        reaction_norm_sum="output/compass_output/LIPID_META_SUBSYSTEM/reactions_norm_sum.tsv",
+        reaction_norm_rank="output/compass_output/LIPID_META_SUBSYSTEM/reactions_norm_rank.tsv"
+    output:
+        reaction_stats_csv="output/group_diff_reaction_stats.tsv",
+        subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",
+        plot="output/red_blue.png"
+    singularity:
+        "/dscolab/vulcan/containers/archimedes-py.sif"
+    script:
+        "scripts/plot_red_blue.py"
+
+rule plot_AA_subsystem_comparison:
+    params:
+        post_process_norm_method=config["post_process_norm_method"],
+        post_process_meta_subsystem="AA_META_SUBSYSTEM"
+    input:
+        group_1_inds="output/diff_group_1__indexes.csv",
+        group_2_inds="output/diff_group_2__indexes.csv",
+        reaction_scores="output/compass_output/AA_META_SUBSYSTEM/reaction_scores.tsv",
+        reaction_norm_sum="output/compass_output/AA_META_SUBSYSTEMreactions_norm_sum.tsv",
+        reaction_norm_rank="output/compass_output/AA_META_SUBSYSTEM/reactions_norm_rank.tsv"
     output:
         reaction_stats_csv="output/group_diff_reaction_stats.tsv",
         subsystem_stats_csv="output/group_diff_subsystem_stats.tsv",

--- a/Snakefile
+++ b/Snakefile
@@ -229,7 +229,7 @@ rule plot_AA_subsystem_comparison:
         group_1_inds="output/diff_group_1__indexes.csv",
         group_2_inds="output/diff_group_2__indexes.csv",
         reaction_scores="output/compass_output/AA_META_SUBSYSTEM/reaction_scores.tsv",
-        reaction_norm_sum="output/compass_output/AA_META_SUBSYSTEMreactions_norm_sum.tsv",
+        reaction_norm_sum="output/compass_output/AA_META_SUBSYSTEM/reactions_norm_sum.tsv",
         reaction_norm_rank="output/compass_output/AA_META_SUBSYSTEM/reactions_norm_rank.tsv"
     output:
         reaction_stats_csv="output/AA_group_diff_reaction_stats.tsv",

--- a/Snakefile
+++ b/Snakefile
@@ -2,9 +2,9 @@ configfile: "config.yaml"
 
 rule all:
     input:
-        thumbnail="output/red_blue.png",
+        thumbnail="output/lipid_red_blue.png",
         compass_tgz="output/compass.tar.gz",
-        all_plots="output/pseudo_qc.png"
+        all_plots=["output/pseudo_qc.png", "output/carbon_red_blue.png", "output/lipid_red_blue.png", "output/AA_red_blue.png"]
 
 rule get_gurobi_license: #UI
     params:

--- a/default-config.json
+++ b/default-config.json
@@ -3,6 +3,5 @@
     "species": "human",
     "min_cells": 10,
     "pre_process_norm_method": "Yes__Only_to_metabolic_genes",
-    "post_process_norm_method": "Rank__rank_reactions_per_pseudobulk",
-    "post_process_meta_subsystem": "LIPID_META_SUBSYSTEM"
+    "post_process_norm_method": "Rank__rank_reactions_per_pseudobulk"
 }

--- a/scripts/plot_red_blue.py
+++ b/scripts/plot_red_blue.py
@@ -21,6 +21,12 @@ reaction_suffix = "norm_sum" if snakemake.config['post_process_norm_method'] == 
 reactions_use = pd.read_csv(snakemake.input[f'reaction_{reaction_suffix}'], sep="\t", index_col = 0)
 reaction_metadata = pd.read_csv(f'output/compass_output/meta_subsystem_models/{subsystem_full}/{subsystem_full}_rxn_meta.csv', index_col = 0)
 
+plot_size = {
+    "LIPID_META_SUBSYSTEM": (10,12),
+    "CENTRAL_CARBON_META_SUBSYSTEM": (10,1.5),
+    "AA_META_SUBSYSTEM": (10,3.5)
+}[subsystem_full]
+
 ### Functions
 def cohens_d(x, y):
     pooled_std = np.sqrt(((len(x)-1) * np.var(x, ddof=1) 
@@ -134,7 +140,7 @@ pd.DataFrame(
 ).to_csv(snakemake.output['subsystem_stats_csv'], sep='\t')
 
 ### Plot
-plt.figure(figsize=(12,12))
+plt.figure(figsize=plot_size)
 axs = plt.gca()
 #Sorts the reactions for plotting
 d = data.groupby('SUBSYSTEM')['cohens_d'].mean()

--- a/scripts/plot_red_blue.py
+++ b/scripts/plot_red_blue.py
@@ -89,7 +89,11 @@ items, counts = np.unique(data['SUBSYSTEM'], return_counts=True)
 items = [items[i] for i in range(len(items)) if counts[i] > 5] #filter(n() > 5) %>%
 data = data[data['SUBSYSTEM'].isin(items)]
 
-data.to_csv(snakemake.output['reaction_stats_csv'], sep='\t')
+# Trim and reorder for output
+data_out = data.copy()
+data_out['cohens_d_abs']=abs(data_out['cohens_d'])
+data_out=data_out.sort_values(by='cohens_d_abs', ascending=False)
+data_out[['cohens_d', 'wilcox_stat', 'wilcox_pval', 'adjusted_pval', 'metadata_r_id', 'NAME', 'EQUATION', 'SUBSYSTEM', 'GENE_ASSOCIATION (SYMBOL)']].to_csv(snakemake.output['reaction_stats_csv'], sep='\t')
 
 data_sig = data[data['adjusted_pval'] < 0.05].copy()
 data_sig_pos = data[(data['adjusted_pval'] < 0.05) & (data['cohens_d'] > 0)].copy()

--- a/scripts/plot_red_blue.py
+++ b/scripts/plot_red_blue.py
@@ -13,14 +13,12 @@ group_A_cells = list(pd.read_csv(snakemake.input['group_1_inds'], header=None)[0
 group_B_cells = list(pd.read_csv(snakemake.input['group_2_inds'], header=None)[0])[1:]
 # Parse reaction file target
 subsystem_full = snakemake.config['post_process_meta_subsystem']
-subsystem = "carbon" if subsystem_full=="CENTRAL_CARBON_META_SUBSYSTEM" \
-    else "lipid" if subsystem_full=="LIPID_META_SUBSYSTEM" \
-    else "AA" if subsystem_full=="AA_META_SUBSYSTEM" \
-    else "NOT FOUND ERROR"
+if not subsystem_full in ["CENTRAL_CARBON_META_SUBSYSTEM", "LIPID_META_SUBSYSTEM", "AA_META_SUBSYSTEM"]:
+    raise Exception("NOT FOUND ERROR")
 reaction_suffix = "norm_sum" if snakemake.config['post_process_norm_method'] == "Sum__divide_by_sum_per_susbsystem" \
     else "norm_rank" if snakemake.config['post_process_norm_method'] == "Rank__rank_reactions_per_pseudobulk" \
     else "scores"
-reactions_use = pd.read_csv(snakemake.input[f'{subsystem}_reaction_{reaction_suffix}'], sep="\t", index_col = 0)
+reactions_use = pd.read_csv(snakemake.input[f'reaction_{reaction_suffix}'], sep="\t", index_col = 0)
 reaction_metadata = pd.read_csv(f'output/compass_output/meta_subsystem_models/{subsystem_full}/{subsystem_full}_rxn_meta.csv', index_col = 0)
 
 ### Functions

--- a/scripts/pseudobulk_data_elements.R
+++ b/scripts/pseudobulk_data_elements.R
@@ -162,8 +162,8 @@ metab_mat <- pseudo_mat[genes_in,]
 dgelist_metab <- calcNormFactors(DGEList(counts = metab_mat), method = "none")
 
 pseudo_meta$metabolism_counts_fraction <- colSums(metab_mat)/colSums(pseudo_mat)
-pseudo_meta$scaling_factors__all_genes <- dgelist_all$samples$norm.factors
-pseudo_meta$scaling_factors__metab_targets <- dgelist_metab$samples$norm.factors
+pseudo_meta$avg_nCounts_per_cell__all_genes <- colSums(pseudo_mat)/pseudo_meta$pseudobulk_cell_num
+pseudo_meta$avg_nCounts_per_cell__metab_targets <- colSums(metab_mat)/pseudo_meta$pseudobulk_cell_num
 
 if (norm_method=="Yes__Only_to_metabolic_genes") {
     logger_ts("Note: Focusing toward metabolic genes only")

--- a/scripts/pseudobulk_qc.R
+++ b/scripts/pseudobulk_qc.R
@@ -36,7 +36,7 @@ ts_log('Plotting')
 png(output_path('all_plots'), w = width*75, h = height*75, res=75)
 yPlot(
     df,
-    c('scaling_factors__all_genes', 'scaling_factors__metab_targets', 'metabolism_counts_fraction'),
+    c('metabolism_counts_fraction', 'avg_nCounts_per_cell__all_genes', 'avg_nCounts_per_cell__metab_targets'),
     ct_col,
     main = "Metabolism Ammount Comparison Metrics",
     sub = "per sample/pseudobulk, grouped by cell type",
@@ -45,8 +45,11 @@ yPlot(
     plots = reps,
     vlnplot.quantiles = c(0.25, 0.5, 0.75),
     vlnplot.lineweight = 0.5,
-    boxplot.width = 0.5,
+    vlnplot.scaling = "width",
+    boxplot.width = 0.8,
+    boxplot.fill = FALSE,
     boxplot.lineweight = 0.5,
+    jitter.width = 0.8,
     legend.show = FALSE)
 dev.off()
 

--- a/scripts/pseudobulk_qc.R
+++ b/scripts/pseudobulk_qc.R
@@ -23,11 +23,11 @@ med_n_samp <- median(table(df[,samp_col], df[,ct_col]))
 
 ### Establish some plot features
 ts_log('Prepping to plot')
-reps <- ifelse(
-    med_n_samp <= 20,
-    c("jitter", "boxplot"),
+reps <- if (med_n_samp <= 20) {
+    c("jitter", "boxplot")
+} else {
     c("jitter", "vlnplot")
-)
+}
 width <- 0.7 + 0.3*n_cts
 height <- 2.5*3 + 0.075*n_char_max_ct
 

--- a/scripts/pseudobulk_qc.R
+++ b/scripts/pseudobulk_qc.R
@@ -15,24 +15,14 @@ samp_col <- input_str('sample_id_column')
 ct_col <- input_str('cell_type_column')
 df <- read.table(input_path('pseudo_metadata'), sep = "\t", header = TRUE, row.names = 1)
 
-ts_log('Reading in data and inputs')
 cts <- unique(df[,ct_col])
 n_cts <- length(cts)
 n_char_max_ct <- max(nchar(cts))
-med_n_samp <- median(table(df[,samp_col], df[,ct_col]))
-
-### Establish some plot features
-ts_log('Prepping to plot')
-reps <- if (med_n_samp <= 20) {
-    c("jitter", "boxplot")
-} else {
-    c("jitter", "vlnplot")
-}
-width <- 0.7 + 0.3*n_cts
-height <- 2.5*3 + 0.075*n_char_max_ct
 
 ### Plot!
 ts_log('Plotting')
+width <- 0.7 + 0.3*n_cts
+height <- 2.5*3 + 0.075*n_char_max_ct
 png(output_path('all_plots'), w = width*75, h = height*75, res=75)
 yPlot(
     df,
@@ -42,13 +32,10 @@ yPlot(
     sub = "per sample/pseudobulk, grouped by cell type",
     split.ncol = 1,
     split.adjust = list(scale = 'free_y'),
-    plots = reps,
+    plots = c("vlnplot", "jitter"),
     vlnplot.quantiles = c(0.25, 0.5, 0.75),
     vlnplot.lineweight = 0.5,
     vlnplot.scaling = "width",
-    boxplot.width = 0.8,
-    boxplot.fill = FALSE,
-    boxplot.lineweight = 0.5,
     jitter.width = 0.8,
     legend.show = FALSE)
 dev.off()

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -50,15 +50,6 @@
   default: "Rank__rank_reactions_per_pseudobulk"
   output:
     params: [ "post_process_norm_method" ]
-- display: "4__Post-processing__Reaction meta-subsystem target"
-  ui_component: "dropdown"
-  doc: "This UI establishes the metabolic meta-subsystem to plot. Note: All three meta-subsystems will be run through compass regardless, so you will be able to cycle through each while analyzing!"
-  default: "LIPID_META_SUBSYSTEM"
-  input:
-    preset:
-      options: ["CENTRAL_CARBON_META_SUBSYSTEM", "AA_META_SUBSYSTEM", "LIPID_META_SUBSYSTEM"]
-  output:
-    params: [ "post_process_meta_subsystem" ]
 
 ## Input UIs
 - display: "Provide your Gurobi License"

--- a/vulcan_config.yaml
+++ b/vulcan_config.yaml
@@ -106,15 +106,41 @@
   ui_component: "collapsible-markdown"
   input:
     files: [ "diff_groups_summary.md" ]
-- display: "Display Differential Reaction Summary Plot"
+- display: "Central Carbon Differential Reaction Summary Plot"
   ui_component: "plot"
   input: 
-    files: [ "red_blue.png" ]
-- display: 'Download Stats Results - Reactions'
+    files: [ "carbon_red_blue.png" ]
+- display: 'Central Carbon Reactions - Stats Download'
   ui_component: "link"
   input:
-    files: [ "group_diff_reaction_stats.tsv" ]
-- display: 'Download Stats Results - Subsystems'
+    files: [ "carbon_group_diff_reaction_stats.tsv" ]
+- display: 'Central Carbon Subsystem - Stats Download'
   ui_component: "link"
   input:
-    files: [ "group_diff_subsystem_stats.tsv" ]
+    files: [ "carbon_group_diff_subsystem_stats.tsv" ]
+- display: "Lipid Differential Reaction Summary Plot"
+  ui_component: "plot"
+  input: 
+    files: [ "lipid_red_blue.png" ]
+- display: 'Lipid Reactions - Stats Download'
+  ui_component: "link"
+  input:
+    files: [ "lipid_group_diff_reaction_stats.tsv" ]
+- display: 'Lipid Subsystem - Stats Download'
+  ui_component: "link"
+  input:
+    files: [ "lipid_group_diff_subsystem_stats.tsv" ]
+- display: "Amino Acid Differential Reaction Summary Plot"
+  ui_component: "plot"
+  input: 
+    files: [ "AA_red_blue.png" ]
+- display: 'Amino Acid Reactions - Stats Download'
+  ui_component: "link"
+  input:
+    files: [ "AA_group_diff_reaction_stats.tsv" ]
+- display: 'Amino Acid Subsystem - Stats Download'
+  ui_component: "link"
+  input:
+    files: [ "AA_group_diff_subsystem_stats.tsv" ]
+
+


### PR DESCRIPTION
PR adjusts the QC plot output that is generated after pseudobulking and CPM normalization to show total counts per pseudobulk (rather than a scale-factor which is now 1 always) per to-be-used metabolic genes vs per all genes.

The change is congruent with the removal of the option to use TMM scale-factor adjustments within the counts normalization.